### PR TITLE
Replace IsAddOnLoaded with C_AddOns.IsAddOnLoaded

### DIFF
--- a/ElvUI_TinkerToolbox/Modules/Scrap.lua
+++ b/ElvUI_TinkerToolbox/Modules/Scrap.lua
@@ -1,4 +1,4 @@
-if not IsAddOnLoaded("Scrap") then return end
+if not C_AddOns.IsAddOnLoaded("Scrap") then return end
 local TT = unpack(ElvUI_TinkerToolbox)
 local E, L, V, P, G = unpack(ElvUI)
 local TTS = TT:NewModule('TinkerToolboxScrap')


### PR DESCRIPTION
This PR fixes this [issue](https://github.com/Azilroka/ElvUI_TinkerToolbox/issues/4), as [IsAddOnLoaded](https://warcraft.wiki.gg/wiki/API_IsAddOnLoaded) has been deprecated, and replaced by [C_AddOns.IsAddOnLoaded](https://warcraft.wiki.gg/wiki/API_C_AddOns.IsAddOnLoaded).
